### PR TITLE
redesign dashboard

### DIFF
--- a/app/pages/Dashboard.tsx
+++ b/app/pages/Dashboard.tsx
@@ -1,28 +1,63 @@
+import { IconChartBar, IconFolder, IconListDetails } from '@tabler/icons-react';
+import { Link } from 'react-router';
+
+import { Button } from '@/components/ui/button';
 import { useUserData } from '@/providers/UserDataProvider';
-import type { Route } from '../+types/root';
 
 export function meta() {
   return [
     { title: 'PMC Admin portal' },
-    { name: 'Dashboard', content: 'Welcome to React Router!' },
+    { name: 'Dashboard', content: 'PMC Admin portal dashboard' },
   ];
 }
 
-export default function Dashboard({
-  loaderData,
-  actionData,
-  params,
-  matches,
-}: Route.ComponentProps) {
+const navCards = [
+  {
+    title: 'Members',
+    description: 'View and manage member records',
+    route: '/members',
+    icon: IconListDetails,
+  },
+  {
+    title: 'Events',
+    description: 'View and manage upcoming events',
+    route: '/events',
+    icon: IconChartBar,
+  },
+  {
+    title: 'Emails',
+    description: 'View and manage email campaigns',
+    route: '/emails',
+    icon: IconFolder,
+  },
+];
+
+export default function Dashboard() {
   const { user } = useUserData();
+  const displayName = user?.user_metadata?.full_name ?? user?.email?.split('@')[0] ?? 'there';
+
   return (
-    <>
-      <h1>this is a dashboard</h1>
-      <p>Loader Data: {JSON.stringify(loaderData)}</p>
-      <p>Action Data: {JSON.stringify(actionData)}</p>
-      <p>Route Parameters: {JSON.stringify(params)}</p>
-      <p>Matched Routes: {JSON.stringify(matches)}</p>
-      <p>User: {JSON.stringify(user)}</p>
-    </>
+    <div className="flex flex-col gap-6 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Welcome back, {displayName}!</h1>
+        <p className="text-muted-foreground">Here's where you can navigate the admin portal.</p>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {navCards.map(({ title, description, route, icon: Icon }) => (
+          <Button
+            key={route}
+            asChild
+            variant="outline"
+            className="h-auto flex-col items-start gap-2 p-4 text-left whitespace-normal"
+          >
+            <Link to={route}>
+              <Icon className="size-6" />
+              <span className="text-base font-medium">{title}</span>
+              <span className="text-muted-foreground font-normal">{description}</span>
+            </Link>
+          </Button>
+        ))}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Description
<!-- In 1-2 sentences, what does this PR do? -->
- redesigned dashboard for navigation to the other admin portal pages

<img width="1154" height="699" alt="Screenshot 2026-07-04 at 8 26 12 PM" src="https://github.com/user-attachments/assets/d00e93ad-8540-4420-99c6-ad2ecff76fa3" />

## Additional Context
<!-- Any follow-ups or related issues. -->
- will need to add the new settings sidebar to this page when @kashgarg merges his changes
